### PR TITLE
Prevent form submit on steg page if no secret key is provided

### DIFF
--- a/steg/templates/steg/select_choice.html
+++ b/steg/templates/steg/select_choice.html
@@ -7,8 +7,8 @@
       <div class="choices-container--item">
         {% csrf_token %}
         <input type="password" name="message" class="normal-input" placeholder="Enter Secret Message">
-        {% for choice in choices %}
-        <input type="submit" value="{{ choice }}" name="type" />
+        {% for choice,class in choices_with_classes.items %}
+        <input type="submit" value="{{ choice }}" name="type" class="{{class}}"/>
         {% endfor %}
       </div>
     </form>

--- a/steg/templates/steg/select_choice.html
+++ b/steg/templates/steg/select_choice.html
@@ -3,7 +3,7 @@
 <div class="choices-container">
   <img src="{{ object.img.url }}" alt="Uploaded Image" />
   <div>
-    <form method="post">
+    <form class="select-choice" method="post">
       <div class="choices-container--item">
         {% csrf_token %}
         <input type="password" name="message" class="normal-input" placeholder="Enter Secret Message">

--- a/steg/views.py
+++ b/steg/views.py
@@ -15,6 +15,8 @@ from steg.functions import hide_lsb, reveal_lsb, hide_lsbset, reveal_lsbset
 
 CHOICES = ["LSB Hide", "LSB Reveal", "LSB Set Hide", "LSB Set Reveal"]
 
+CHOICES_WITH_CLASSES = {"LSB Hide":"prevent", "LSB Reveal":"", "LSB Set Hide":"prevent", "LSB Set Reveal":""}
+
 class ProcessImage(View):
     def get(self, request, choice):
         # messages.success(request, "Updated successfully!")
@@ -69,6 +71,7 @@ class SelectChoice(View):
         context={
                 "object": obj, 
                 "choices": CHOICES,
+                "choices_with_classes": CHOICES_WITH_CLASSES
                 }
         return render(request, "steg/select_choice.html", context)
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -73,5 +73,15 @@
     <script src="{% static 'js/index.js' %}"></script>
     <script src="{% static 'js/menu.js' %}"></script>
     <script src="{% static 'js/upload.js' %}"></script>
-
+    <script>
+        console.log($)
+        $('.select-choice').on('submit', function(e) {
+            if ($(".normal-input").val() == "") {
+                alert("Pls enter a secret key");
+                e.preventDefault();
+            } else {
+                $('.select-choice').submit()
+            }
+        });
+    </script>
 </html5>

--- a/templates/base.html
+++ b/templates/base.html
@@ -74,14 +74,11 @@
     <script src="{% static 'js/menu.js' %}"></script>
     <script src="{% static 'js/upload.js' %}"></script>
     <script>
-        console.log($)
-        $('.select-choice').on('submit', function(e) {
+        $('.prevent').on('click', function(e) {
             if ($(".normal-input").val() == "") {
                 alert("Pls enter a secret key");
                 e.preventDefault();
-            } else {
-                $('.select-choice').submit()
             }
-        });
+        })
     </script>
 </html5>


### PR DESCRIPTION
Please Provide The following Details About your PR

Type x Inside the checkbox to tick it

## Description

In this PR, I have added an event listener on the hide related submit action in the form on the Steganography page to prevent the form submission if the secret key provided is empty.
![image](https://user-images.githubusercontent.com/84830429/198822070-d87a00b4-db78-4d83-8573-8deeb9d6f0b9.png)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
